### PR TITLE
Allow Identity Learning Rate Scheduler

### DIFF
--- a/pytorch_fob/optimizers/lr_schedulers/__init__.py
+++ b/pytorch_fob/optimizers/lr_schedulers/__init__.py
@@ -30,7 +30,7 @@ def get_lr_scheduler(optimizer: torch.optim.Optimizer, config: OptimizerConfig) 
     if config.lr_scheduler.warmup_steps is None or config.lr_scheduler.scheduler == "identity":
         base_scheduler = IdentityLR
         scheduler_kwargs = dict()
-    if config.lr_scheduler.scheduler == "cosine":
+    elif config.lr_scheduler.scheduler == "cosine":
         base_scheduler = CosineAnnealingLR
         scheduler_kwargs = dict(
             T_max=scheduler_steps,

--- a/pytorch_fob/optimizers/wadam/default.yaml
+++ b/pytorch_fob/optimizers/wadam/default.yaml
@@ -1,0 +1,6 @@
+optimizer:
+  name: wadam # same as folder name
+  learning_rate: 1.e-3
+  beta1: 0.9            # beta1 parameter
+  beta2: 0.9            # beta1 parameter
+  epsilon: 1.0e-30

--- a/pytorch_fob/optimizers/wadam/default.yaml
+++ b/pytorch_fob/optimizers/wadam/default.yaml
@@ -1,6 +1,6 @@
 optimizer:
   name: wadam # same as folder name
-  learning_rate: 1.e-3
+  learning_rate: 1.0e-3
   beta1: 0.9            # beta1 parameter
   beta2: 0.9            # beta1 parameter
-  epsilon: 1.0e-30
+  epsilon: 1.0e-8

--- a/pytorch_fob/optimizers/wadam/optimizer.py
+++ b/pytorch_fob/optimizers/wadam/optimizer.py
@@ -1,0 +1,136 @@
+# code from: https://github.com/jettify/pytorch-optimizer/blob/master/torch_optimizer/adafactor.py
+
+import math
+from typing import Any
+
+import torch
+from torch.optim.optimizer import Optimizer
+
+from lightning.pytorch.utilities.types import OptimizerLRScheduler
+from pytorch_fob.engine.configs import OptimizerConfig
+from pytorch_fob.engine.parameter_groups import GroupedModel
+from pytorch_fob.optimizers.lr_schedulers import get_lr_scheduler
+
+
+
+class WAdam(Optimizer):
+    """Implements Welfordized Adam.
+
+    Arguments:
+        params: iterable of parameters to optimize or dicts defining
+            parameter groups
+        lr: external learning rate (default: None)
+        eps: regularization constans for square gradient
+            and parameter scale respectively (default: (1e-30, 1e-3))
+        beta1: coefficient used for computing running averages of gradient
+            (default: None)
+        beta2: coefficient used for computing running averages of gradient
+            (default: None)
+    """
+
+    def __init__(
+        self,
+        params,
+        lr: float = 1e-3,
+        beta1: float = 0.9,
+        beta2 = None,
+        epsilon = 1e-7,
+    ):
+        if lr is not None and lr <= 0.0:
+            raise ValueError("Invalid learning rate: {}".format(lr))
+        if beta1 < 0.0:
+            raise ValueError(
+                "Invalid beta1 value: {}".format(beta1)
+            )
+        if beta2 is None:
+            beta2 = beta1
+        if beta2 < 0.0:
+            raise ValueError(
+                "Invalid beta2 value: {}".format(beta2)
+            )
+        if epsilon < 0.0:
+            raise ValueError(
+                "Invalid epsilon value: {}".format(epsilon)
+            )
+
+        hyperparams = dict(
+            lr=lr,
+            beta1=beta1,
+            beta2=beta2,
+            epsilon=epsilon,
+        )
+        super(WAdam, self).__init__(params, hyperparams)
+
+    def step(self, closure = None) -> float | None:
+        r"""Performs a single optimization step.
+
+        Arguments:
+            closure: A closure that reevaluates the model and returns the loss.
+        """
+        loss = None
+        if closure is not None:
+            loss = closure()
+
+        for group in self.param_groups:
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                g = p.grad.data
+                if g.is_sparse:
+                    raise RuntimeError(
+                        "Adafactor does not support sparse gradients."
+                    )
+
+                state = self.state[p]
+                grad_shape = g.shape
+
+                # State Initialization
+                if len(state) == 0:
+                    state["step"] = 0
+                    state["running_mean"] = torch.zeros(
+                        grad_shape[:-1]
+                    ).type_as(grad)
+                    state["running_variance"] = torch.zeros(
+                        grad_shape[-1:]
+                    ).type_as(grad)
+
+                step = state['step']
+                step.add(1)
+                m = state['running_mean']
+                v = state['running_variance']
+
+                delta = g - m
+                m.add((1. - beta1) * delta)
+                v.add(
+                    (beta2 - 1.) * v + (1. - beta2) * delta * (g - m)
+                )
+
+                #Debiased step size
+                lr = self._get_lr(group, state)
+                beta1_power = beta1 ** step
+                beta2_power = beta2 ** step
+                alpha = lr * torch.sqrt(1. - beta2_power) / (1. - beta1_power)
+                p.data.sub((m * alpha) / (torch.sqrt(v) + eps))
+
+        return loss
+
+def configure_optimizers(model: GroupedModel, config: OptimizerConfig) -> OptimizerLRScheduler:
+    lr = config.learning_rate
+    beta1 = config.beta1
+    beta2 = config.beta2
+    epsilon = config.epsilon
+    optimizer = WAdam(
+        model.grouped_parameters(lr=lr), 
+        lr=lr, 
+        beta1=beta1, 
+        beta2=beta2,
+        epsilon=epsilon,
+    )
+    lr_scheduler = get_lr_scheduler(optimizer, config)
+    return {
+        "optimizer": optimizer,
+        "lr_scheduler": {
+            "scheduler": lr_scheduler,
+            "interval": config.lr_scheduler.interval
+        }
+    }

--- a/pytorch_fob/optimizers/wadam/optimizer.py
+++ b/pytorch_fob/optimizers/wadam/optimizer.py
@@ -114,7 +114,6 @@ class WAdam(Optimizer):
                 beta1_power = beta1 ** step
                 beta2_power = beta2 ** step
                 alpha = lr * math.sqrt(1. - beta2_power) / (1. - beta1_power)
-                print(f'learning rate: {lr}')
                 p.data.sub_((m * alpha) / (torch.sqrt(v) + eps))
 
         return loss


### PR DESCRIPTION
The control flow in `pytorch_fob/optimizers/lr_schedulers/__init__.py` was preventing me from setting the `scheduler` to "identity". I think this change restores it to the intended pattern, but maybe I'm missing something with how this is supposed to work. 