### PR TITLE
allow identity scheduler

### DIFF
--- a/pytorch_fob/optimizers/lr_schedulers/__init__.py
+++ b/pytorch_fob/optimizers/lr_schedulers/__init__.py
@@ -30,7 +30,7 @@ def get_lr_scheduler(optimizer: torch.optim.Optimizer, config: OptimizerConfig) 
     if config.lr_scheduler.warmup_steps is None or config.lr_scheduler.scheduler == "identity":
         base_scheduler = IdentityLR
         scheduler_kwargs = dict()
-    if config.lr_scheduler.scheduler == "cosine":
+    elif config.lr_scheduler.scheduler == "cosine":
         base_scheduler = CosineAnnealingLR
         scheduler_kwargs = dict(
             T_max=scheduler_steps,


### PR DESCRIPTION
The control flow in `pytorch_fob/optimizers/lr_schedulers/__init__.py:get_lr_scheduler` was blocking me from setting `scheduler: identity`. I think this PR sets it back to how it is supposed to function. Of course, I could be missing something here. I'm still getting familiar with the code base. 

Thanks for this project! 